### PR TITLE
removes the pushup menu from the article view

### DIFF
--- a/sailfishos/qml/phone/pages/ArticlePage.qml
+++ b/sailfishos/qml/phone/pages/ArticlePage.qml
@@ -87,25 +87,6 @@ Page {
             }
         }
 
-        PushUpMenu {
-            MenuItem {
-                //% "Scroll to top"
-                text: qsTrId("fuoten-scroll-to-top")
-                visible: articleFlick.contentHeight > articleFlick.height
-                onClicked: articleFlick.scrollToTop()
-            }
-            MenuItem {
-                text: qsTrId("fuoten-share")
-                enabled: article
-                onClicked: pageStack.push(Qt.resolvedUrl("../../common/pages/Sharing.qml"), {"shareUrl": article.url.toString(), "shareTitle": article.title })
-            }
-            MenuItem {
-                text: qsTrId("fuoten-open-in-browser")
-                onClicked: Qt.openUrlExternally(article.url)
-                enabled: article
-            }
-        }
-
         ColumnLayout {
             id: headerCol
             spacing: Theme.paddingSmall


### PR DESCRIPTION
@buschmann23 first, are you still maintaining the app? There was not much movement lately, sadly.

This PR essentially removes the PushUp menu from the article view (on the phone). That's mostly a UX improvement, a least from my  PoV: while reading an article I am constantly scrolling down, the eyes on one position, so I don't know or see when the end of the articles comes. But then, the menu becomes active and too often I end up on "Scroll on top", loosing my reading position. 

Functionality is not really lost: auto-scrolling to top works with the native Silica scroll decorations, the other items are available on the top menu. 

It is understandable if you would not like that approach, but then we can look for a way to make it work for everybody? Settings are always possible, but ideally they are avoided as much as possible… All provided you are still interested in maintaining the app, of course.
